### PR TITLE
Apply WordPress coding standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,21 @@
+# This file is for unifying the coding style for different editors and IDEs
+# editorconfig.org
+
+# WordPress Coding Standards
+# https://make.wordpress.org/core/handbook/coding-standards/
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = tab
+
+[{*.json,*.yml}]
+indent_style = space
+indent_size = 2
+
+[{*.txt,wp-config-sample.php}]
+end_of_line = crlf

--- a/dgxpco.php
+++ b/dgxpco.php
@@ -31,8 +31,8 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-define( 'DGXPCO_PATH', dirname( __FILE__) . '/' );
-define( 'DGXPCO_BASENAME', plugin_basename( __FILE__) );
+define( 'DGXPCO_PATH', dirname( __FILE__ ) . '/' );
+define( 'DGXPCO_BASENAME', plugin_basename( __FILE__ ) );
 
 require_once __DIR__ . '/vendor/autoload.php';
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -161,8 +161,10 @@ function pre_download( $reply, $package, $upgrader ) {
 		$upgrader->skin->feedback( __( 'No signature available for package. Skipping check as configured&#8230;', 'dgxpco' ) );
 		$signature = false;
 	} else {
+		// phpcs:disable WordPress.WP.AlternativeFunctions
 		$signature_json = file_get_contents( $signature_file );
-		$signature_obj  = json_decode( $signature_json );
+		// phpcs:enable
+		$signature_obj = json_decode( $signature_json );
 		unlink( $signature_file );
 
 		$signature = $signature_obj->signature;

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -48,7 +48,7 @@ function i18n() {
  */
 function get_public_keys() {
 	$known_keys = [
-		\ParagonIE_Sodium_Compat::hex2bin( '5d4c696e571307b4a47626ae0bf9a7a229403c46657b4a9e832fee47e253bc5b' )
+		\ParagonIE_Sodium_Compat::hex2bin( '5d4c696e571307b4a47626ae0bf9a7a229403c46657b4a9e832fee47e253bc5b' ),
 	];
 
 	/**

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -20,12 +20,7 @@ function activate() {
 }
 
 /**
- * Default setup routine
- *
- * @uses add_action()
- * @uses do_action()
- *
- * @return void
+ * Default setup routine.
  */
 function setup() {
 	$n = function ( $function ) {
@@ -39,14 +34,6 @@ function setup() {
 
 /**
  * Registers the default textdomain.
- *
- * @uses apply_filters()
- * @uses get_locale()
- * @uses load_textdomain()
- * @uses load_plugin_textdomain()
- * @uses plugin_basename()
- *
- * @return void
  */
 function i18n() {
 	$locale = apply_filters( 'plugin_locale', get_locale(), 'dgxpco' );
@@ -55,7 +42,7 @@ function i18n() {
 }
 
 /**
- * Return an array of trusted Ed25519 public keys
+ * Return an array of trusted Ed25519 public keys.
  *
  * @return array
  */
@@ -79,7 +66,7 @@ function get_public_keys() {
  * @param array  $publicKeys
  * @param string $signature
  *
- * @return bool|object WP_Error on failure, true on success
+ * @return bool|object WP_Error on failure, true on success.
  */
 function verify_file_ed25519( $filename, $publicKeys, $signature ) {
 	if ( \ParagonIE_Sodium_Core_Util::strlen( $signature ) === \ParagonIE_Sodium_Compat::CRYPTO_SIGN_BYTES * 2 ) {
@@ -114,12 +101,12 @@ function verify_file_ed25519( $filename, $publicKeys, $signature ) {
  * @return bool|\WP_Error
  */
 function pre_download( $reply, $package, $upgrader ) {
-	// If we're already aborting, abort
+	// If we're already aborting, abort.
 	if ( false !== $reply ) {
 		return $reply;
 	}
 
-	// If this isn't a core update, abort
+	// If this isn't a core update, abort.
 	if ( ! preg_match( '!^https://downloads\.wordpress\.org/release/wordpress-\d\.\d\.\d.*\.zip!i', $package ) ) {
 		return $reply;
 	}
@@ -128,13 +115,13 @@ function pre_download( $reply, $package, $upgrader ) {
 		return new \WP_Error( 'no_package', $upgrader->strings['no_package'] );
 	}
 
-	// Get the signature for this file first
+	// Get the signature for this file first.
 	$message        = sprintf( __( 'Downloading package signature from %s&#8230;', 'dgxpco' ), '<span class="code">%s</span>' );
 	$signature_path = 'https://releasesignatures.displace.tech/wordpress/' . basename( $package ) . '.sig';
 	$upgrader->skin->feedback( sprintf( $message, $signature_path ) );
 	$signature_file = download_url( $signature_path );
 
-	// No signature
+	// No signature.
 	if ( is_wp_error( $signature_file ) ) {
 		/**
 		 * Signatures are required for all core updates by default. If, for some reason, you wish to allow

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -12,12 +12,11 @@ namespace DisplaceTech\DGXPCO;
  *
  * We will _never_ download core updates over unencrypted connections. If SSL support is missing, abort!
  */
-function activate()
-{
-    if (!wp_http_supports(['ssl'])) {
-        deactivate_plugins(DGXPCO_BASENAME);
-        exit(esc_html__('Serverside SSL support is not available. DGXPCO has been deactivated.', 'dgxpco'));
-    }
+function activate() {
+	if ( ! wp_http_supports( [ 'ssl' ] ) ) {
+		deactivate_plugins( DGXPCO_BASENAME );
+		exit( esc_html__( 'Serverside SSL support is not available. DGXPCO has been deactivated.', 'dgxpco' ) );
+	}
 }
 
 /**
@@ -28,15 +27,14 @@ function activate()
  *
  * @return void
  */
-function setup()
-{
-    $n = function ($function) {
-        return __NAMESPACE__ . "\\$function";
-    };
+function setup() {
+	$n = function ( $function ) {
+		return __NAMESPACE__ . "\\$function";
+	};
 
-    add_action('init', $n('i18n'));
+	add_action( 'init', $n( 'i18n' ) );
 
-    do_action('dgxpco_loaded');
+	do_action( 'dgxpco_loaded' );
 }
 
 /**
@@ -50,11 +48,10 @@ function setup()
  *
  * @return void
  */
-function i18n()
-{
-    $locale = apply_filters('plugin_locale', get_locale(), 'dgxpco');
-    load_textdomain('dgxpco', WP_LANG_DIR . '/dgxpco/dgxpco-' . $locale . '.mo');
-    load_plugin_textdomain('dgxpco', false, plugin_basename(DGXPCO_PATH) . '/languages/');
+function i18n() {
+	$locale = apply_filters( 'plugin_locale', get_locale(), 'dgxpco' );
+	load_textdomain( 'dgxpco', WP_LANG_DIR . '/dgxpco/dgxpco-' . $locale . '.mo' );
+	load_plugin_textdomain( 'dgxpco', false, plugin_basename( DGXPCO_PATH ) . '/languages/' );
 }
 
 /**
@@ -62,45 +59,43 @@ function i18n()
  *
  * @return array
  */
-function get_public_keys()
-{
-    $known_keys = [
-        \ParagonIE_Sodium_Compat::hex2bin('5d4c696e571307b4a47626ae0bf9a7a229403c46657b4a9e832fee47e253bc5b')
-    ];
+function get_public_keys() {
+	$known_keys = [
+		\ParagonIE_Sodium_Compat::hex2bin( '5d4c696e571307b4a47626ae0bf9a7a229403c46657b4a9e832fee47e253bc5b' )
+	];
 
-    /**
-     * Filter the array of know, trusted Ed25519 signing keys.
-     *
-     * @param array $known_keys
-     */
-    return apply_filters('dgxpco_trusted_keys', $known_keys);
+	/**
+	 * Filter the array of know, trusted Ed25519 signing keys.
+	 *
+	 * @param array $known_keys
+	 */
+	return apply_filters( 'dgxpco_trusted_keys', $known_keys );
 }
 
 /**
  * Verifies the Ed25519 signature of a file for a given set of public keys.
  *
  * @param string $filename
- * @param array $publicKeys
+ * @param array  $publicKeys
  * @param string $signature
  *
  * @return bool|object WP_Error on failure, true on success
  */
-function verify_file_ed25519($filename, $publicKeys, $signature)
-{
-    if (\ParagonIE_Sodium_Core_Util::strlen($signature) === \ParagonIE_Sodium_Compat::CRYPTO_SIGN_BYTES * 2) {
-        $signature = \ParagonIE_Sodium_Compat::hex2bin($signature);
-    }
+function verify_file_ed25519( $filename, $publicKeys, $signature ) {
+	if ( \ParagonIE_Sodium_Core_Util::strlen( $signature ) === \ParagonIE_Sodium_Compat::CRYPTO_SIGN_BYTES * 2 ) {
+		$signature = \ParagonIE_Sodium_Compat::hex2bin( $signature );
+	}
 
-    foreach ($publicKeys as $public_key) {
-        if (\ParagonIE_Sodium_Core_Util::strlen($public_key) === \ParagonIE_Sodium_Compat::CRYPTO_SIGN_PUBLICKEYBYTES * 2) {
-            $public_key = \ParagonIE_Sodium_Compat::hex2bin($public_key);
-        }
-        if (\ParagonIE_Sodium_File::verify($signature, $filename, $public_key)) {
-            return true;
-        }
-    }
+	foreach ( $publicKeys as $public_key ) {
+		if ( \ParagonIE_Sodium_Core_Util::strlen( $public_key ) === \ParagonIE_Sodium_Compat::CRYPTO_SIGN_PUBLICKEYBYTES * 2 ) {
+			$public_key = \ParagonIE_Sodium_Compat::hex2bin( $public_key );
+		}
+		if ( \ParagonIE_Sodium_File::verify( $signature, $filename, $public_key ) ) {
+			return true;
+		}
+	}
 
-    return new \WP_Error('ed25519_mismatch', sprintf(__('The signature of the file (%1$s) is not valid for any of the trusted public keys.', 'dxgpco'), bin2hex($signature)));
+	return new \WP_Error( 'ed25519_mismatch', sprintf( __( 'The signature of the file (%1$s) is not valid for any of the trusted public keys.', 'dxgpco' ), bin2hex( $signature ) ) );
 }
 
 /**
@@ -112,79 +107,79 @@ function verify_file_ed25519($filename, $publicKeys, $signature)
  *
  * If the package is unknown file, passthru for standard operations.
  *
- * @param bool $reply
- * @param string $package
+ * @param bool         $reply
+ * @param string       $package
  * @param \WP_Upgrader $upgrader
  *
  * @return bool|\WP_Error
  */
-function pre_download($reply, $package, $upgrader)
-{
-    // If we're already aborting, abort
-    if (false !== $reply) {
-        return $reply;
-    }
+function pre_download( $reply, $package, $upgrader ) {
+	// If we're already aborting, abort
+	if ( false !== $reply ) {
+		return $reply;
+	}
 
-    // If this isn't a core update, abort
-    if (!preg_match('!^https://downloads\.wordpress\.org/release/wordpress-\d\.\d\.\d.*\.zip!i', $package)) {
-        return $reply;
-    }
+	// If this isn't a core update, abort
+	if ( ! preg_match( '!^https://downloads\.wordpress\.org/release/wordpress-\d\.\d\.\d.*\.zip!i', $package ) ) {
+		return $reply;
+	}
 
-    if (empty($package)) {
-        return new \WP_Error('no_package', $upgrader->strings['no_package']);
-    }
+	if ( empty( $package ) ) {
+		return new \WP_Error( 'no_package', $upgrader->strings['no_package'] );
+	}
 
-    // Get the signature for this file first
-    $message = sprintf(__('Downloading package signature from %s&#8230;', 'dgxpco'), '<span class="code">%s</span>');
-    $signature_path = 'https://releasesignatures.displace.tech/wordpress/' . basename($package) . '.sig';
-    $upgrader->skin->feedback(sprintf($message, $signature_path));
-    $signature_file = download_url($signature_path);
+	// Get the signature for this file first
+	$message        = sprintf( __( 'Downloading package signature from %s&#8230;', 'dgxpco' ), '<span class="code">%s</span>' );
+	$signature_path = 'https://releasesignatures.displace.tech/wordpress/' . basename( $package ) . '.sig';
+	$upgrader->skin->feedback( sprintf( $message, $signature_path ) );
+	$signature_file = download_url( $signature_path );
 
-    // No signature
-    if (is_wp_error($signature_file)) {
-        /**
-         * Signatures are required for all core updates by default. If, for some reason, you wish to allow
-         * updates without checking the signature, use this filter to bypass the signature check.
-         *
-         * Or, you know, just disable the plugin because you'll be operating in the wild wild west anyway.
-         *
-         * Your decision.
-         *
-         * @param bool $require_signatures
-         */
-        $require_signatures = apply_filters('dgxpco_require_signatures', true);
-        if ($require_signatures) {
-            return new \WP_Error('missing_signature', sprintf(__('No signature available for package: %s', 'dgxpco'), $package));
-        }
+	// No signature
+	if ( is_wp_error( $signature_file ) ) {
+		/**
+		 * Signatures are required for all core updates by default. If, for some reason, you wish to allow
+		 * updates without checking the signature, use this filter to bypass the signature check.
+		 *
+		 * Or, you know, just disable the plugin because you'll be operating in the wild wild west anyway.
+		 *
+		 * Your decision.
+		 *
+		 * @param bool $require_signatures
+		 */
+		$require_signatures = apply_filters( 'dgxpco_require_signatures', true );
+		if ( $require_signatures ) {
+			return new \WP_Error( 'missing_signature', sprintf( __( 'No signature available for package: %s', 'dgxpco' ), $package ) );
+		}
 
-        $upgrader->skin->feedback(__('No signature available for package. Skipping check as configured&#8230;', 'dgxpco'));
-        $signature = false;
-    } else {
-        $signature_json = file_get_contents($signature_file);
-        $signature_obj = json_decode($signature_json);
-        unlink($signature_file);
+		$upgrader->skin->feedback( __( 'No signature available for package. Skipping check as configured&#8230;', 'dgxpco' ) );
+		$signature = false;
+	} else {
+		$signature_json = file_get_contents( $signature_file );
+		$signature_obj  = json_decode( $signature_json );
+		unlink( $signature_file );
 
-        $signature = $signature_obj->signature;
-    }
+		$signature = $signature_obj->signature;
+	}
 
-    $upgrader->skin->feedback('downloading_package', $package);
+	$upgrader->skin->feedback( 'downloading_package', $package );
 
-    $download_file = download_url($package);
+	$download_file = download_url( $package );
 
-    if (is_wp_error($download_file)) {
-        return new \WP_Error('download_failed', $upgrader->strings['download_failed'], $download_file->get_error_message());
-    }
+	if ( is_wp_error( $download_file ) ) {
+		return new \WP_Error( 'download_failed', $upgrader->strings['download_failed'], $download_file->get_error_message() );
+	}
 
-    if ($signature) {
-        $upgrader->skin->feedback(__('Verifying package signature&#8230;', 'dgxpco'));
+	if ( $signature ) {
+		$upgrader->skin->feedback( __( 'Verifying package signature&#8230;', 'dgxpco' ) );
 
-        $public_keys = get_public_keys();
-        $ed25519_check = verify_file_ed25519($download_file, $public_keys, $signature);
-        if (is_wp_error($ed25519_check)) {
-            unlink($download_file);
-            return $ed25519_check;
-        }
-    }
+		$public_keys   = get_public_keys();
+		$ed25519_check = verify_file_ed25519( $download_file, $public_keys, $signature );
 
-    return $download_file;
+		if ( is_wp_error( $ed25519_check ) ) {
+			unlink( $download_file );
+			return $ed25519_check;
+		}
+	}
+
+	return $download_file;
 }

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -2,19 +2,7 @@
 <ruleset name="WordPress Coding Standards for Plugins">
 	<description>Generally-applicable sniffs for WordPress plugins</description>
 
-	<rule ref="WordPress-Core">
-	    <!-- We use PSR-1/2 here ... so ignore some things -->
-	    <exclude name="PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket" />
-	    <exclude name="PEAR.Functions.FunctionCallSignature.SpaceBeforeCloseBracket" />
-	    <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.OpenBraceNotSameLine" />
-	    <exclude name="Generic.Functions.OpeningFunctionBraceKernighanRitchie.BraceOnNewLine" />
-	    <exclude name="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed" />
-	    <exclude name="WordPress.WhiteSpace.OperatorSpacing.NoSpaceBefore" />
-	    <exclude name="WordPress.WhiteSpace.OperatorSpacing.NoSpaceAfter" />
-	    <exclude name="WordPress.Arrays.ArrayDeclarationSpacing.NoSpaceAfterArrayOpener" />
-	    <exclude name="WordPress.Arrays.ArrayDeclarationSpacing.NoSpaceAfterArrayCloser" />
-	    <exclude name="WordPress.WhiteSpace.ControlStructureSpacing.NoSpaceBeforeCloseParenthesis" />
-	</rule>
+	<rule ref="WordPress-Extra" />
 	<rule ref="WordPress-Docs" />
 
 	<!-- Check all PHP files in directory tree by default. -->


### PR DESCRIPTION
This PR cleans up the codebase to use the WordPress coding standards. Additionally, I've imported namespaces at the top of the file, enabling them to be referenced more cleanly throughout the file (e.g. no `new \WP_Error()`).

The one item that doesn't quite hit WP coding standards is the use of `file_get_contents()`, as the standards prefer that you use the built-in WordPress HTTP API. For the way this is being used, I feel that `file_get_contents()` is perfectly acceptable, so I temporarily disabled that sniff via inline comment.